### PR TITLE
Minor: Removed unused dependencies from examples.

### DIFF
--- a/examples/bar_chart/Cargo.toml
+++ b/examples/bar_chart/Cargo.toml
@@ -8,5 +8,4 @@ edition = "2021"
 [dependencies]
 leptos = {version = "0.4.1", features=["csr"]}
 leptos_chart = {path = "../../leptos_chart", version = "0.1.0", features = ["BarChart", "debug"]}
-log = "0.4.6"
 wasm-logger = "0.2.0"

--- a/examples/bar_chart_group/Cargo.toml
+++ b/examples/bar_chart_group/Cargo.toml
@@ -8,5 +8,4 @@ edition = "2021"
 [dependencies]
 leptos = {version = "0.4.1", features=["csr"]}
 leptos_chart = {path = "../../leptos_chart", version = "0.1.0", features = ["BarChart", "debug"]}
-log = "0.4.6"
 wasm-logger = "0.2.0"

--- a/examples/line_chart/Cargo.toml
+++ b/examples/line_chart/Cargo.toml
@@ -8,5 +8,4 @@ edition = "2021"
 [dependencies]
 leptos = {version = "0.4.1", features=["csr"]}
 leptos_chart = {path = "../../leptos_chart", version = "0.1.0", features = ["LineChart", "debug"]}
-log = "0.4.6"
 wasm-logger = "0.2.0"

--- a/examples/line_chart_group/Cargo.toml
+++ b/examples/line_chart_group/Cargo.toml
@@ -8,5 +8,4 @@ edition = "2021"
 [dependencies]
 leptos = {version = "0.4.1", features=["csr"]}
 leptos_chart = {path = "../../leptos_chart", version = "0.1.0", features = ["LineChartGroup", "debug"]}
-log = "0.4.6"
 wasm-logger = "0.2.0"

--- a/examples/pie_chart/Cargo.toml
+++ b/examples/pie_chart/Cargo.toml
@@ -8,5 +8,4 @@ edition = "2021"
 [dependencies]
 leptos = {version = "0.4.1"}
 leptos_chart = {path = "../../leptos_chart", version = "0.1.0", features = ["PieChart", "debug"]}
-log = "0.4.6"
 wasm-logger = "0.2.0"

--- a/examples/radar_chart/Cargo.toml
+++ b/examples/radar_chart/Cargo.toml
@@ -8,5 +8,4 @@ edition = "2021"
 [dependencies]
 leptos = {version = "0.4.1"}
 leptos_chart = {path = "../../leptos_chart", version = "0.1.0", features = ["RadarChart", "debug"]}
-log = "0.4.6"
 wasm-logger = "0.2.0"

--- a/examples/scatter_chart/Cargo.toml
+++ b/examples/scatter_chart/Cargo.toml
@@ -8,5 +8,4 @@ edition = "2021"
 [dependencies]
 leptos = {version = "0.4.1", features=["csr"]}
 leptos_chart = {path = "../../leptos_chart", version = "0.1.0", features = ["ScatterChart", "debug"]}
-log = "0.4.6"
 wasm-logger = "0.2.0"


### PR DESCRIPTION
I like this crate, I think it will be useful...

When I ran 

```cargo machete```

[cargo-machete](https://crates.io/crates/cargo-machete) is used to identify un-used sub-crates

"log" is no longer used in the examples. "wasm-logger" is its replacement.