### PR TITLE
Minor: Fix workspace resolver issue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,7 @@
 [workspace]
-members = [  
-  "leptos_chart",
-]
+resolver = "2"
+members = ["leptos_chart"]
 exclude = ["examples"]
 
 [workspace.package]
 version = "0.1.2"
-
-
-


### PR DESCRIPTION
I really like this crate ...

When I run cargo update I see this lint warning 

``` 
warning: some crates are on edition 2021 which defaults to `resolver = "2"`, but virtual workspaces default to `resolver = "1"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
```

this PR fixes it