### PR TITLE
Migrated leptos from 0.4.1 to 0.5.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,4 +4,4 @@ members = ["leptos_chart"]
 exclude = ["examples"]
 
 [workspace.package]
-version = "0.1.2"
+version = "0.2.0"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The project provides chart types to draw for leptos.
 #### Cargo.toml for PieChart
 
 ```toml
-leptos = {version = "0.4.1"}
+leptos = {version = "0.5.1"}
 leptos_chart = {version = "0.1.0", features = ["PieChart"]}
 ```
 
@@ -29,18 +29,18 @@ use leptos_chart::*;
 
 fn main() {
     wasm_logger::init(wasm_logger::Config::default());
-    leptos::mount_to_body(|cx| leptos::view! { cx,  <App/> })
+    leptos::mount_to_body(|| leptos::view! { <App/> })
 }
 
 #[component]
-pub fn App(cx: Scope) -> impl IntoView {
+pub fn App() -> impl IntoView {
     let chart = Polar::new(
         Series::from(vec![1.0, 2.0, 3.]),
         Series::from(vec!["A", "B", "C"]),
     )
     .set_view(740, 540, 1, 200, 20);
 
-    view! {cx,
+    view! {
         <div class="mx-auto p-8" style="background:#00000077">
             <h1>"Pie chart example with right label"</h1>
             <PieChart chart=chart />
@@ -62,7 +62,7 @@ pub fn App(cx: Scope) -> impl IntoView {
 #### Cargo.toml for BarChart
 
 ```toml
-leptos = {version = "0.4.1"}
+leptos = {version = "0.5.1"}
 leptos_chart = {version = "0.1.0", features = ["BarChart"]}
 ```
 
@@ -74,11 +74,11 @@ use leptos_chart::*;
 
 fn main() {
     wasm_logger::init(wasm_logger::Config::default());
-    leptos::mount_to_body(|cx| leptos::view! { cx,  <App/> })
+    leptos::mount_to_body(|| leptos::view! {  <App/> })
 }
 
 #[component]
-pub fn App(cx: Scope) -> impl IntoView {
+pub fn App() -> impl IntoView {
     let chart_v = Cartesian::new(
         Series::from(vec!["A", "B", "C"]),
         Series::from(vec![1.0, 6.0, 9.]),
@@ -91,7 +91,7 @@ pub fn App(cx: Scope) -> impl IntoView {
     )
     .set_view(820, 620, 3, 30, 30, 20);
 
-    view! {cx,
+    view! {
         <div class="mx-auto p-8" style="background:#00000077">
 
             <h1>"Bar chart example"</h1>
@@ -116,7 +116,7 @@ pub fn App(cx: Scope) -> impl IntoView {
 #### Cargo.toml for BarChartGroup
 
 ```toml
-leptos = {version = "0.4.1"}
+leptos = {version = "0.5.1"}
 leptos_chart = {version = "0.1.0", features = ["BarChart"]}
 ```
 
@@ -128,11 +128,11 @@ use leptos_chart::*;
 
 fn main() {
     wasm_logger::init(wasm_logger::Config::default());
-    leptos::mount_to_body(|cx| leptos::view! { cx,  <App/> })
+    leptos::mount_to_body(|| leptos::view! { <App/> })
 }
 
 #[component]
-pub fn App(cx: Scope) -> impl IntoView {
+pub fn App() -> impl IntoView {
     let chart = CartesianGroup::new()
         .set_view(840, 640, 3, 50, 50, 20)
         .add_data(
@@ -144,7 +144,7 @@ pub fn App(cx: Scope) -> impl IntoView {
             Series::from(vec![0.3, 0.5, 0.9]),
         );
 
-    view! {cx,
+    view! {
         <div class="mx-auto p-8">
             <h1>"Bar chart stack example"</h1>
             <BarChartGroup chart=chart />
@@ -163,7 +163,7 @@ pub fn App(cx: Scope) -> impl IntoView {
 #### Cargo.toml for LineChart
 
 ```toml
-leptos = {version = "0.4.1"}
+leptos = {version = "0.5.1"}
 leptos_chart = {version = "0.1.0", features = ["LineChart"]}
 ```
 
@@ -175,18 +175,18 @@ use leptos_chart::*;
 
 fn main() {
     wasm_logger::init(wasm_logger::Config::default());
-    leptos::mount_to_body(|cx| leptos::view! { cx,  <App/> })
+    leptos::mount_to_body(|| leptos::view! { <App/> })
 }
 
 #[component]
-pub fn App(cx: Scope) -> impl IntoView {
+pub fn App() -> impl IntoView {
     let chart = Cartesian::new(
         Series::from(vec![0., 1.0, 2.]),
         Series::from(vec![3.0, 1.0, 5.]),
     )
     .set_view(820, 620, 3, 100, 100, 20);
 
-    view! {cx,
+    view! {
         <div class="mx-auto p-8" style="background:#00000077">
             <h1>"Line chart example"</h1>
             <LineChart chart=chart />
@@ -204,7 +204,7 @@ pub fn App(cx: Scope) -> impl IntoView {
 #### Cargo.toml for LineChartGroup
 
 ```toml
-leptos = {version = "0.4.1"}
+leptos = {version = "0.5.1"}
 leptos_chart = {version = "0.1.0", features = ["LineChartGroup"]}
 ```
 
@@ -216,24 +216,24 @@ use leptos_chart::*;
 
 fn main() {
     wasm_logger::init(wasm_logger::Config::default());
-    leptos::mount_to_body(|cx| leptos::view! { cx,  <App/> })
+    leptos::mount_to_body(|| leptos::view! { <App/> })
 }
 
 #[component]
-pub fn App(cx: Scope) -> impl IntoView {
-    
-    let chart = CartesianGroup::new()    
-    .set_view(840, 640, 3, 50, 50, 20)   
+pub fn App() -> impl IntoView {
+
+    let chart = CartesianGroup::new()
+    .set_view(840, 640, 3, 50, 50, 20)
     .add_data(
         Series::from((vec!["1982", "1986", "2010", "2020", ], "%Y", "year")),
-        Series::from(vec![3., 2.0, 1., 4.]),        
+        Series::from(vec![3., 2.0, 1., 4.]),
     )
     .add_data(
         Series::from((vec!["1982", "1986", "2017", "2020"], "%Y", "year")),
-        Series::from(vec![0., 1.0, 2., 3.]),        
+        Series::from(vec![0., 1.0, 2., 3.]),
     );
 
-    view! {cx,
+    view! {
         <div class="mx-auto p-8">
             <h1>"Line chart group example"</h1>
             <LineChartGroup chart=chart />
@@ -251,7 +251,7 @@ pub fn App(cx: Scope) -> impl IntoView {
 #### Cargo.toml for RadarChart
 
 ```toml
-leptos = {version = "0.4.1"}
+leptos = {version = "0.5.1"}
 leptos_chart = {version = "0.1.0", features = ["RadarChart"]}
 ```
 
@@ -263,18 +263,18 @@ use leptos_chart::*;
 
 fn main() {
     wasm_logger::init(wasm_logger::Config::default());
-    leptos::mount_to_body(|cx| leptos::view! { cx,  <App/> })
+    leptos::mount_to_body(|| leptos::view! { <App/> })
 }
 
 #[component]
-pub fn App(cx: Scope) -> impl IntoView {
+pub fn App(x: Scope) -> impl IntoView {
     let chart = Polar::new(
         Series::from(vec![85.0, 55.0, 45., 60., 40.]),
         Series::from(vec!["Reading", "Writing", "Listening", "Speaking", "React"]),
     )
     .set_view(740, 540, 1, 0, 20);
 
-    view! {cx,
+    view! {
         <div class="mx-auto p-8">
             <h1>"Radar chart example"</h1>
             <RadarChart chart=chart />
@@ -292,7 +292,7 @@ pub fn App(cx: Scope) -> impl IntoView {
 #### Cargo.toml for ScatterChart
 
 ```toml
-leptos = {version = "0.4.1"}
+leptos = {version = "0.5.1"}
 leptos_chart = {version = "0.1.0", features = ["ScatterChart"]}
 ```
 
@@ -304,11 +304,11 @@ use leptos_chart::*;
 
 fn main() {
     wasm_logger::init(wasm_logger::Config::default());
-    leptos::mount_to_body(|cx| leptos::view! { cx,  <App/> })
+    leptos::mount_to_body(|| leptos::view! { <App/> })
 }
 
 #[component]
-pub fn App(cx: Scope) -> impl IntoView {
+pub fn App() -> impl IntoView {
     let chart = Cartesian::new(
         Series::from(vec![50,60,70,80,90,100,110,120,130,140,150])
             .set_range(40., 160.),
@@ -317,7 +317,7 @@ pub fn App(cx: Scope) -> impl IntoView {
     )
     .set_view(820, 620, 3, 100, 100, 20);
 
-    view! {cx,
+    view! {
         <div class="mx-auto p-8">
             <h1>"Scatter chart example"</h1>
             <ScatterChart chart=chart />

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The project provides chart types to draw for leptos.
 
 ```toml
 leptos = {version = "0.5.1"}
-leptos_chart = {version = "0.1.0", features = ["PieChart"]}
+.0leptos_chart = {version = "0.2", features = ["PieChart"]}
 ```
 
 #### main.rs for PieChart
@@ -63,7 +63,7 @@ pub fn App() -> impl IntoView {
 
 ```toml
 leptos = {version = "0.5.1"}
-leptos_chart = {version = "0.1.0", features = ["BarChart"]}
+leptos_chart = {version = "0.2.0", features = ["BarChart"]}
 ```
 
 #### main.rs for BarChart
@@ -117,7 +117,7 @@ pub fn App() -> impl IntoView {
 
 ```toml
 leptos = {version = "0.5.1"}
-leptos_chart = {version = "0.1.0", features = ["BarChart"]}
+leptos_chart = {version = "0.2.0", features = ["BarChart"]}
 ```
 
 #### main.rs for BarChartGroup
@@ -164,7 +164,7 @@ pub fn App() -> impl IntoView {
 
 ```toml
 leptos = {version = "0.5.1"}
-leptos_chart = {version = "0.1.0", features = ["LineChart"]}
+leptos_chart = {version = "0.2.0", features = ["LineChart"]}
 ```
 
 #### main.rs for LineChart
@@ -205,7 +205,7 @@ pub fn App() -> impl IntoView {
 
 ```toml
 leptos = {version = "0.5.1"}
-leptos_chart = {version = "0.1.0", features = ["LineChartGroup"]}
+leptos_chart = {version = "0.2.0", features = ["LineChartGroup"]}
 ```
 
 #### main.rs for LineChartGroup
@@ -252,7 +252,7 @@ pub fn App() -> impl IntoView {
 
 ```toml
 leptos = {version = "0.5.1"}
-leptos_chart = {version = "0.1.0", features = ["RadarChart"]}
+leptos_chart = {version = "0.2.0", features = ["RadarChart"]}
 ```
 
 #### main.rs for RadarChart
@@ -293,7 +293,7 @@ pub fn App(x: Scope) -> impl IntoView {
 
 ```toml
 leptos = {version = "0.5.1"}
-leptos_chart = {version = "0.1.0", features = ["ScatterChart"]}
+leptos_chart = {version = "0.2.0", features = ["ScatterChart"]}
 ```
 
 #### main.rs for ScatterChart

--- a/examples/bar_chart/Cargo.toml
+++ b/examples/bar_chart/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 leptos = { version = "0.5.1", features = ["csr"] }
-leptos_chart = { path = "../../leptos_chart", version = "0.1.0", features = [
+leptos_chart = { path = "../../leptos_chart", version = "0.2.0", features = [
   "BarChart",
   "debug",
 ] }

--- a/examples/bar_chart/Cargo.toml
+++ b/examples/bar_chart/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-leptos = {version = "0.4.1", features=["csr"]}
-leptos_chart = {path = "../../leptos_chart", version = "0.1.0", features = ["BarChart", "debug"]}
+leptos = { version = "0.5.1", features = ["csr"] }
+leptos_chart = { path = "../../leptos_chart", version = "0.1.0", features = [
+  "BarChart",
+  "debug",
+] }
 wasm-logger = "0.2.0"

--- a/examples/bar_chart/src/main.rs
+++ b/examples/bar_chart/src/main.rs
@@ -3,11 +3,11 @@ use leptos_chart::*;
 
 fn main() {
     wasm_logger::init(wasm_logger::Config::default());
-    leptos::mount_to_body(|cx| leptos::view! { cx,  <App/> })
+    leptos::mount_to_body(|| leptos::view! {  <App/> })
 }
 
 #[component]
-pub fn App(cx: Scope) -> impl IntoView {
+pub fn App() -> impl IntoView {
     let chart_v = Cartesian::new(
         Series::from(vec!["A", "B", "C"]),
         Series::from(vec![1.0, 6.0, 9.]),
@@ -20,7 +20,7 @@ pub fn App(cx: Scope) -> impl IntoView {
     )
     .set_view(820, 620, 3, 30, 30, 20);
 
-    view! {cx,
+    view! {
         <div class="mx-auto p-8">
 
             <h1>"Bar chart example"</h1>

--- a/examples/bar_chart_group/Cargo.toml
+++ b/examples/bar_chart_group/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-leptos = {version = "0.4.1", features=["csr"]}
-leptos_chart = {path = "../../leptos_chart", version = "0.1.0", features = ["BarChart", "debug"]}
+leptos = { version = "0.5.1", features = ["csr"] }
+leptos_chart = { path = "../../leptos_chart", version = "0.1.0", features = [
+  "BarChart",
+  "debug",
+] }
 wasm-logger = "0.2.0"

--- a/examples/bar_chart_group/src/main.rs
+++ b/examples/bar_chart_group/src/main.rs
@@ -3,11 +3,11 @@ use leptos_chart::*;
 
 fn main() {
     wasm_logger::init(wasm_logger::Config::default());
-    leptos::mount_to_body(|cx| leptos::view! { cx,  <App/> })
+    leptos::mount_to_body(|| leptos::view! { <App/> })
 }
 
 #[component]
-pub fn App(cx: Scope) -> impl IntoView {
+pub fn App() -> impl IntoView {
     let chart = CartesianGroup::new()
         .set_view(840, 640, 3, 50, 50, 20)
         .add_data(
@@ -19,7 +19,7 @@ pub fn App(cx: Scope) -> impl IntoView {
             Series::from(vec![0.3, 0.5, 0.9]),
         );
 
-    view! {cx,
+    view! {
         <div class="mx-auto p-8">
             <h1>"Bar chart group example"</h1>
             <BarChartGroup chart=chart />

--- a/examples/line_chart/Cargo.toml
+++ b/examples/line_chart/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 leptos = { version = "0.5.1", features = ["csr"] }
-leptos_chart = { path = "../../leptos_chart", version = "0.1.0", features = [
+leptos_chart = { path = "../../leptos_chart", version = "0.2.0", features = [
   "LineChart",
   "debug",
 ] }

--- a/examples/line_chart/Cargo.toml
+++ b/examples/line_chart/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-leptos = {version = "0.4.1", features=["csr"]}
-leptos_chart = {path = "../../leptos_chart", version = "0.1.0", features = ["LineChart", "debug"]}
+leptos = { version = "0.5.1", features = ["csr"] }
+leptos_chart = { path = "../../leptos_chart", version = "0.1.0", features = [
+  "LineChart",
+  "debug",
+] }
 wasm-logger = "0.2.0"

--- a/examples/line_chart/src/main.rs
+++ b/examples/line_chart/src/main.rs
@@ -3,21 +3,24 @@ use leptos_chart::*;
 
 fn main() {
     wasm_logger::init(wasm_logger::Config::default());
-    leptos::mount_to_body(|cx| leptos::view! { cx,  <App/> })
+    leptos::mount_to_body(|| leptos::view! { <App/> })
 }
 
 #[component]
-pub fn App(cx: Scope) -> impl IntoView {
+pub fn App() -> impl IntoView {
     let chart = Cartesian::new(
         // Series::from((vec!["1982", "1986", "2017", "2020"], "%Y", "year")),
         // Series::from((vec!["1982-04", "1986-02", "2017-02", "2020-05"], "%Y-%m", "month")),
         Series::from(vec![0., 1.0, 2., 3.]),
-        Series::from((vec!["1982-03", "1982-07", "1983-02", "1983-04"], "%Y-%m", "month")),
-        
+        Series::from((
+            vec!["1982-03", "1982-07", "1983-02", "1983-04"],
+            "%Y-%m",
+            "month",
+        )),
     )
     .set_view(820, 620, 3, 100, 100, 20);
 
-    view! {cx,
+    view! {
         <div class="mx-auto p-8">
             <h1>"Line chart example"</h1>
             <LineChart chart=chart />

--- a/examples/line_chart_group/Cargo.toml
+++ b/examples/line_chart_group/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-leptos = {version = "0.4.1", features=["csr"]}
-leptos_chart = {path = "../../leptos_chart", version = "0.1.0", features = ["LineChartGroup", "debug"]}
+leptos = { version = "0.5.1", features = ["csr"] }
+leptos_chart = { path = "../../leptos_chart", version = "0.1.0", features = [
+  "LineChartGroup",
+  "debug",
+] }
 wasm-logger = "0.2.0"

--- a/examples/line_chart_group/src/main.rs
+++ b/examples/line_chart_group/src/main.rs
@@ -3,24 +3,23 @@ use leptos_chart::*;
 
 fn main() {
     wasm_logger::init(wasm_logger::Config::default());
-    leptos::mount_to_body(|cx| leptos::view! { cx,  <App/> })
+    leptos::mount_to_body(|| leptos::view! { <App/> })
 }
 
 #[component]
-pub fn App(cx: Scope) -> impl IntoView {
-    
-    let chart = CartesianGroup::new()    
-    .set_view(840, 640, 3, 50, 50, 20)   
-    .add_data(
-        Series::from((vec!["1982", "1986", "2010", "2020", ], "%Y", "year")),
-        Series::from(vec![3., 2.0, 1., 4.]),        
-    )
-    .add_data(
-        Series::from((vec!["1982", "1986", "2017", "2020"], "%Y", "year")),
-        Series::from(vec![0., 1.0, 2., 3.]),        
-    );
+pub fn App() -> impl IntoView {
+    let chart = CartesianGroup::new()
+        .set_view(840, 640, 3, 50, 50, 20)
+        .add_data(
+            Series::from((vec!["1982", "1986", "2010", "2020"], "%Y", "year")),
+            Series::from(vec![3., 2.0, 1., 4.]),
+        )
+        .add_data(
+            Series::from((vec!["1982", "1986", "2017", "2020"], "%Y", "year")),
+            Series::from(vec![0., 1.0, 2., 3.]),
+        );
 
-    view! {cx,
+    view! {
         <div class="mx-auto p-8">
             <h1>"Line chart group example"</h1>
             <LineChartGroup chart=chart />

--- a/examples/pie_chart/Cargo.toml
+++ b/examples/pie_chart/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-leptos = {version = "0.4.1"}
-leptos_chart = {path = "../../leptos_chart", version = "0.1.0", features = ["PieChart", "debug"]}
+leptos = { version = "0.5.1" }
+leptos_chart = { path = "../../leptos_chart", version = "0.1.0", features = [
+  "PieChart",
+  "debug",
+] }
 wasm-logger = "0.2.0"

--- a/examples/pie_chart/Cargo.toml
+++ b/examples/pie_chart/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 leptos = { version = "0.5.1" }
-leptos_chart = { path = "../../leptos_chart", version = "0.1.0", features = [
+leptos_chart = { path = "../../leptos_chart", version = "0.2.0", features = [
   "PieChart",
   "debug",
 ] }

--- a/examples/pie_chart/src/main.rs
+++ b/examples/pie_chart/src/main.rs
@@ -3,18 +3,18 @@ use leptos_chart::*;
 
 fn main() {
     wasm_logger::init(wasm_logger::Config::default());
-    leptos::mount_to_body(|cx| leptos::view! { cx,  <App/> })
+    leptos::mount_to_body(|| leptos::view! { <App/> })
 }
 
 #[component]
-pub fn App(cx: Scope) -> impl IntoView {
+pub fn App() -> impl IntoView {
     let chart = Polar::new(
         Series::from(vec![1.0, 2.0, 5.]),
         Series::from(vec!["A", "B", "C"]),
     )
     .set_view(740, 540, 1, 200, 20);
 
-    view! {cx,
+    view! {
         <div class="mx-auto p-8">
             <h1>"Pie chart example with right label"</h1>
             <PieChart chart=chart />

--- a/examples/radar_chart/Cargo.toml
+++ b/examples/radar_chart/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-leptos = {version = "0.4.1"}
-leptos_chart = {path = "../../leptos_chart", version = "0.1.0", features = ["RadarChart", "debug"]}
+leptos = { version = "0.5.1" }
+leptos_chart = { path = "../../leptos_chart", version = "0.1.0", features = [
+  "RadarChart",
+  "debug",
+] }
 wasm-logger = "0.2.0"

--- a/examples/radar_chart/src/main.rs
+++ b/examples/radar_chart/src/main.rs
@@ -3,18 +3,18 @@ use leptos_chart::*;
 
 fn main() {
     wasm_logger::init(wasm_logger::Config::default());
-    leptos::mount_to_body(|cx| leptos::view! { cx,  <App/> })
+    leptos::mount_to_body(|| leptos::view! { <App/> })
 }
 
 #[component]
-pub fn App(cx: Scope) -> impl IntoView {
+pub fn App() -> impl IntoView {
     let chart = Polar::new(
         Series::from(vec![85.0, 55.0, 45., 60., 40.]),
         Series::from(vec!["Reading", "Writing", "Listening", "Speaking", "React"]),
     )
     .set_view(740, 540, 1, 0, 20);
 
-    view! {cx,
+    view! {
         <div class="mx-auto p-8">
             <h1>"Radar chart example"</h1>
             <RadarChart chart=chart />

--- a/examples/scatter_chart/Cargo.toml
+++ b/examples/scatter_chart/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 leptos = { version = "0.5.1", features = ["csr"] }
-leptos_chart = { path = "../../leptos_chart", version = "0.1.0", features = [
+leptos_chart = { path = "../../leptos_chart", version = "0.2.0", features = [
   "ScatterChart",
   "debug",
 ] }

--- a/examples/scatter_chart/Cargo.toml
+++ b/examples/scatter_chart/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-leptos = {version = "0.4.1", features=["csr"]}
-leptos_chart = {path = "../../leptos_chart", version = "0.1.0", features = ["ScatterChart", "debug"]}
+leptos = { version = "0.5.1", features = ["csr"] }
+leptos_chart = { path = "../../leptos_chart", version = "0.1.0", features = [
+  "ScatterChart",
+  "debug",
+] }
 wasm-logger = "0.2.0"

--- a/examples/scatter_chart/src/main.rs
+++ b/examples/scatter_chart/src/main.rs
@@ -3,18 +3,18 @@ use leptos_chart::*;
 
 fn main() {
     wasm_logger::init(wasm_logger::Config::default());
-    leptos::mount_to_body(|cx| leptos::view! { cx,  <App/> })
+    leptos::mount_to_body(|| leptos::view! { <App/> })
 }
 
 #[component]
-pub fn App(cx: Scope) -> impl IntoView {
+pub fn App() -> impl IntoView {
     let chart = Cartesian::new(
-        Series::from(vec![50,60,70,80,90,100,110,120,130,140,150]).set_range(40., 160.),
-        Series::from(vec![7,8,8,9,9,9,10,11,14,14,15]).set_range(6., 16.),
+        Series::from(vec![50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150]).set_range(40., 160.),
+        Series::from(vec![7, 8, 8, 9, 9, 9, 10, 11, 14, 14, 15]).set_range(6., 16.),
     )
     .set_view(820, 620, 3, 100, 100, 20);
 
-    view! {cx,
+    view! {
         <div class="mx-auto p-8">
             <h1>"Scatter chart example"</h1>
             <ScatterChart chart=chart />

--- a/leptos_chart/Cargo.toml
+++ b/leptos_chart/Cargo.toml
@@ -9,8 +9,8 @@ description = "Chart library for leptos"
 readme = "../README.md"
 
 [dependencies]
-leptos = {version = "0.4",  features = ["csr"]}
-theta-chart = { version = "0.0.6"}
+leptos = { version = "0.5.1", features = ["csr"] }
+theta-chart = { version = "0.0.6" }
 log = "0.4"
 
 [features]

--- a/leptos_chart/src/axes/xaxis.rs
+++ b/leptos_chart/src/axes/xaxis.rs
@@ -1,11 +1,11 @@
-use leptos::{component, view, IntoView, Scope};
+use leptos::{component, view, IntoView};
 use theta_chart::coord::{Axes, Rec};
 
 use crate::core::REM;
 
 #[allow(non_snake_case)]
 #[component]
-pub fn XAxis(cx: Scope, region: Rec, axes: Axes) -> impl IntoView {
+pub fn XAxis(region: Rec, axes: Axes) -> impl IntoView {
     let vector = region.get_vector();
     let mut mark_origin_y = REM;
     let mut baseline = "text-before-edge";
@@ -23,13 +23,13 @@ pub fn XAxis(cx: Scope, region: Rec, axes: Axes) -> impl IntoView {
         text_anchor = "";
     }
 
-    view! {cx,
+    view! {
         // Draw region of x-axis
         {
             #[cfg(feature = "debug")]
             {
                 let path = format!("M {},{} l {},{} l {},{} l {},{} Z", 0, 0, vector.get_x(), 0, 0,vector.get_y(), -vector.get_x(), 0);
-                view! {cx,
+                view! {
                     <circle id="originX" cx="0" cy="0" r="3" />
                     <line x1="0" y1="0" x2=vector.get_x() y2=vector.get_y() style="stroke:#ff000033;stroke-width:1" />
                     <path id="regionX" d=path  fill="#ff000033" />
@@ -43,7 +43,7 @@ pub fn XAxis(cx: Scope, region: Rec, axes: Axes) -> impl IntoView {
                 {
                     axes.sticks.into_iter().map(|stick| {
                         let dx = stick.value * vector.get_x();
-                        view! {cx,
+                        view! {
                             <line x1=dx y1="0" x2=dx y2={mark_origin_y/2.} style="stroke:rgb(255,0,0)" />
                             <text
                                 y={mark_origin_y}

--- a/leptos_chart/src/axes/yaxis.rs
+++ b/leptos_chart/src/axes/yaxis.rs
@@ -1,11 +1,11 @@
-use leptos::{component, view, IntoView, Scope};
+use leptos::{component, view, IntoView};
 use theta_chart::coord::{Axes, Rec};
 
 use crate::core::REM;
 
 #[allow(non_snake_case)]
 #[component]
-pub fn YAxis(cx: Scope, region: Rec, axes: Axes) -> impl IntoView {
+pub fn YAxis(region: Rec, axes: Axes) -> impl IntoView {
     let vector = region.get_vector();
     let mut mark_origin_x = REM;
     let mut text_anchor = "start";
@@ -15,13 +15,13 @@ pub fn YAxis(cx: Scope, region: Rec, axes: Axes) -> impl IntoView {
         text_anchor = "end";
     }
 
-    view! {cx,
+    view! {
         // Draw region of y-axis
         {
             #[cfg(feature = "debug")]
             {
                 let path = format!("M {},{} l {},{} l {},{} l {},{} Z", 0, 0, vector.get_x(), 0, 0,vector.get_y(), -vector.get_x(), 0);
-                view! {cx,
+                view! {
                     <circle id="originY" cx="0" cy="0" r="3" />
                     <line x1="0" y1="0" x2=vector.get_x() y2=vector.get_y() style="stroke:#0000ff33;stroke-width:2" />
                     <path id="regionY" d=path  fill="#0000ff33" />
@@ -36,7 +36,7 @@ pub fn YAxis(cx: Scope, region: Rec, axes: Axes) -> impl IntoView {
             {
                 axes.sticks.into_iter().map(|stick| {
                     let dy = stick.value * vector.get_y();
-                    view! {cx,
+                    view! {
                         <line x1="0" y1=dy x2={mark_origin_x/2.} y2=dy style="stroke:rgb(255,0,0)" />
                         <text
                             y=dy

--- a/leptos_chart/src/barchart/components.rs
+++ b/leptos_chart/src/barchart/components.rs
@@ -14,7 +14,7 @@ use theta_chart::{color::Color, coord, series::Series};
 /// ```toml
 /// [dependencies]
 /// leptos = {version = "0.5.1"}
-/// leptos_chart = {version = "0.1.0", features = ["BarChart"]}
+/// leptos_chart = {version = "0.2.0", features = ["BarChart"]}
 /// ```
 ///
 /// ## Component

--- a/leptos_chart/src/barchart/components.rs
+++ b/leptos_chart/src/barchart/components.rs
@@ -2,7 +2,7 @@ use crate::{
     axes::{XAxis, YAxis},
     core::SvgChart,
 };
-use leptos::{component, view, IntoView, Scope};
+use leptos::{component, view, IntoView};
 use theta_chart::{color::Color, coord, series::Series};
 
 /// Component BarChart for leptos
@@ -13,7 +13,7 @@ use theta_chart::{color::Color, coord, series::Series};
 ///
 /// ```toml
 /// [dependencies]
-/// leptos = {version = "0.4.1"}
+/// leptos = {version = "0.5.1"}
 /// leptos_chart = {version = "0.1.0", features = ["BarChart"]}
 /// ```
 ///
@@ -23,14 +23,14 @@ use theta_chart::{color::Color, coord, series::Series};
 /// use leptos_chart::*;
 ///
 /// #[component]
-/// pub fn App(cx: Scope) -> impl IntoView {
+/// pub fn App() -> impl IntoView {
 ///     let chart_v = Cartesian::new(
 ///         Series::from(vec!["A", "B", "C"]),
 ///         Series::from(vec![1.0, 6.0, 9.]),
 ///     )
 ///     .set_view(820, 620, 3, 50, 50, 20);
 ///
-///     view!{ cx,
+///     view!{
 ///         <BarChart data=data />
 ///     }
 /// }
@@ -61,7 +61,7 @@ use theta_chart::{color::Color, coord, series::Series};
 ///
 #[allow(non_snake_case)]
 #[component]
-pub fn BarChart(cx: Scope, chart: coord::Cartesian) -> impl IntoView {
+pub fn BarChart(chart: coord::Cartesian) -> impl IntoView {
     let cview = chart.get_view();
 
     // For Chart
@@ -104,7 +104,7 @@ pub fn BarChart(cx: Scope, chart: coord::Cartesian) -> impl IntoView {
         _ => x_is_label = false,
     }
 
-    view! { cx,
+    view! {
 
         <SvgChart cview={cview}>
             <g class="axes">
@@ -122,7 +122,7 @@ pub fn BarChart(cx: Scope, chart: coord::Cartesian) -> impl IntoView {
                     {
                         let vector = rec_chart.get_vector();
                         let path = format!("M {},{} l {},{} l {},{} l {},{} Z", 0, 0, vector.get_x(), 0, 0,vector.get_y(), -vector.get_x(), 0);
-                        view! {cx,
+                        view! {
                             <circle id="origin" cx="0" cy="0" r="3" />
                             <line x1="0" y1="0" x2=vector.get_x() y2=vector.get_y() style="stroke:#00ff0033;stroke-width:2" />
                             <path id="region" d=path  fill="#00ff0033" />
@@ -140,7 +140,7 @@ pub fn BarChart(cx: Scope, chart: coord::Cartesian) -> impl IntoView {
                             let x: f64 = xseries.scale(data.value + 0.5) * vector.get_x();
                             let y: f64 = yseries.scale(ysticks[index].value) *vector.get_y();
 
-                            view! {cx,
+                            view! {
                                 <line x1=x y1="0" x2=x y2=y style=style.clone() />
                             }
                         })
@@ -151,7 +151,7 @@ pub fn BarChart(cx: Scope, chart: coord::Cartesian) -> impl IntoView {
                         xsticks.into_iter().enumerate().map(|(index, data)|  {
                             let x: f64 = xseries.scale(data.value) * vector.get_x();
                             let y: f64 = yseries.scale(ysticks[index].value +0.5) * vector.get_y();
-                            view! {cx,
+                            view! {
                                 <line x1="0" y1=y x2=x y2=y style=style.clone() />
                             }
                         })

--- a/leptos_chart/src/barchart_group/components.rs
+++ b/leptos_chart/src/barchart_group/components.rs
@@ -2,7 +2,7 @@ use crate::{
     axes::{XAxis, YAxis},
     core::SvgChart,
 };
-use leptos::{component, view, IntoView, Scope};
+use leptos::{component, view, IntoView};
 use theta_chart::{color::Color, coord, series::Series};
 
 /// Component LineChart for leptos
@@ -13,7 +13,7 @@ use theta_chart::{color::Color, coord, series::Series};
 ///
 /// ```toml
 /// [dependencies]
-/// leptos = {version = "0.4.1"}
+/// leptos = {version = "0.5.1"}
 /// leptos_chart = {version = "0.1.0", features = ["BarChartGroup"]}
 /// ```
 ///
@@ -23,7 +23,7 @@ use theta_chart::{color::Color, coord, series::Series};
 /// use leptos_chart::*;
 ///
 /// #[component]
-/// pub fn App(cx: Scope) -> impl IntoView {
+/// pub fn App() -> impl IntoView {
 /// let chart = CartesianGroup::new()
 ///     .set_view(840, 640, 3, 50, 50, 20)
 ///     .add_data(
@@ -35,7 +35,7 @@ use theta_chart::{color::Color, coord, series::Series};
 ///         Series::from(vec![0.3, 0.5, 0.9]),
 ///     );
 ///
-///     view!{ cx,
+///     view!{
 ///         <BarChartGroup chart=chart />
 ///     }
 /// }
@@ -63,7 +63,7 @@ use theta_chart::{color::Color, coord, series::Series};
 ///
 #[allow(non_snake_case)]
 #[component]
-pub fn BarChartGroup(cx: Scope, chart: coord::CartesianGroup) -> impl IntoView {
+pub fn BarChartGroup(chart: coord::CartesianGroup) -> impl IntoView {
     let cview = chart.get_view();
 
     // For Chart
@@ -110,7 +110,7 @@ pub fn BarChartGroup(cx: Scope, chart: coord::CartesianGroup) -> impl IntoView {
         _ => x_is_label = false,
     }
 
-    view! { cx,
+    view! {
 
         <SvgChart cview={cview}>
             <g class="axes">
@@ -128,7 +128,7 @@ pub fn BarChartGroup(cx: Scope, chart: coord::CartesianGroup) -> impl IntoView {
                     {
                         let vector = rec_chart.get_vector();
                         let path = format!("M {},{} l {},{} l {},{} l {},{} Z", 0, 0, vector.get_x(), 0, 0,vector.get_y(), -vector.get_x(), 0);
-                        view! {cx,
+                        view! {
                             <circle id="origin" cx="0" cy="0" r="3" />
                             <line x1="0" y1="0" x2=vector.get_x() y2=vector.get_y() style="stroke:#00ff0033;stroke-width:2" />
                             <path id="region" d=path  fill="#00ff0033" />
@@ -161,7 +161,7 @@ pub fn BarChartGroup(cx: Scope, chart: coord::CartesianGroup) -> impl IntoView {
                                 let label = data.label;
                                 let x: f64 = ((series_x_group.scale_index(label.clone()) as f64/ (len_group as f64)) as f64) * vector.get_x() + (position * index as f64 + position/2. + 0.05) * interval ;
                                 let y: f64 = series_y_group.scale(ystick[indexi].value) *vector.get_y();
-                                view! {cx,
+                                view! {
                                     <line x1=x y1="0" x2=x y2=y style=style.clone() />
                                 }
                             })
@@ -191,7 +191,7 @@ pub fn BarChartGroup(cx: Scope, chart: coord::CartesianGroup) -> impl IntoView {
                                 let x: f64 = series_x_group.scale(xstick[indexi].value) *vector.get_x();
                                 let y: f64 = ((series_y_group.scale_index(label.clone()) as f64/ (len_group as f64)) as f64) * vector.get_y() + (position * index as f64 + position/2. + 0.05) * interval ;
 
-                                view! {cx,
+                                view! {
                                     <line x1="0" y1=y x2=x y2=y style=style.clone() />
                                 }
                             })

--- a/leptos_chart/src/barchart_group/components.rs
+++ b/leptos_chart/src/barchart_group/components.rs
@@ -14,7 +14,7 @@ use theta_chart::{color::Color, coord, series::Series};
 /// ```toml
 /// [dependencies]
 /// leptos = {version = "0.5.1"}
-/// leptos_chart = {version = "0.1.0", features = ["BarChartGroup"]}
+/// leptos_chart = {version = "0.2.0", features = ["BarChartGroup"]}
 /// ```
 ///
 /// ## Component

--- a/leptos_chart/src/core/svg_chart.rs
+++ b/leptos_chart/src/core/svg_chart.rs
@@ -4,25 +4,25 @@ use theta_chart::coord::*;
 // Wrap chart in SVG
 #[cfg(any(doc, feature = "core"))]
 #[component]
-pub fn SvgChart(cx: Scope, cview: CView, children: Children) -> impl IntoView {
+pub fn SvgChart(cview: CView, children: Children) -> impl IntoView {
     let margin = cview.get_margin();
 
     let translate_chart = format!("translate({},{})", margin, margin);
     let vec_chart = cview.get_vector();
     let view_box = format!("0 0 {} {}", vec_chart.get_x(), vec_chart.get_y());
-    view! { cx,
+    view! {
         <svg class="chart" viewBox=view_box>
             {
                 #[cfg(feature = "debug")]
                 {
-                    view! {cx,
+                    view! {
                         <rect width={vec_chart.get_x()} height={vec_chart.get_y()} fill="#005bbe11"></rect>
                     }
                 }
             }
             <g class="inner-view" transform={translate_chart} >
 
-                {children(cx)}
+                {children()}
             </g>
 
         </svg>

--- a/leptos_chart/src/core/svg_polar.rs
+++ b/leptos_chart/src/core/svg_polar.rs
@@ -4,25 +4,25 @@ use theta_chart::coord::*;
 // Wrap chart in SVG
 #[cfg(any(doc, feature = "core"))]
 #[component]
-pub fn SvgPolar(cx: Scope, pview: PView, children: Children) -> impl IntoView {
+pub fn SvgPolar(pview: PView, children: Children) -> impl IntoView {
     let margin = pview.get_margin();
 
     let translate_chart = format!("translate({},{})", margin, margin);
     let vec_chart = pview.get_vector();
     let view_box = format!("0 0 {} {}", vec_chart.get_x(), vec_chart.get_y());
-    view! { cx,
+    view! {
         <svg class="chart" viewBox=view_box>
             {
                 #[cfg(feature = "debug")]
                 {
-                    view! {cx,
+                    view! {
                         <rect width={vec_chart.get_x()} height={vec_chart.get_y()} fill="#005bbe11"></rect>
                     }
                 }
             }
 
             <g class="inner-view" transform={translate_chart} >
-                {children(cx)}
+                {children()}
             </g>
 
         </svg>

--- a/leptos_chart/src/linechart/components.rs
+++ b/leptos_chart/src/linechart/components.rs
@@ -14,7 +14,7 @@ use theta_chart::coord;
 /// ```toml
 /// [dependencies]
 /// leptos = {version = "0.5.1"}
-/// leptos_chart = {version = "0.1.0", features = ["LineChart"]}
+/// leptos_chart = {version = "0.2.0", features = ["LineChart"]}
 /// ```
 ///
 /// ## Component

--- a/leptos_chart/src/linechart/components.rs
+++ b/leptos_chart/src/linechart/components.rs
@@ -2,7 +2,7 @@ use crate::{
     axes::{XAxis, YAxis},
     core::SvgChart,
 };
-use leptos::{component, view, IntoView, Scope};
+use leptos::{component, view, IntoView};
 use theta_chart::coord;
 
 /// Component LineChart for leptos
@@ -13,7 +13,7 @@ use theta_chart::coord;
 ///
 /// ```toml
 /// [dependencies]
-/// leptos = {version = "0.4.1"}
+/// leptos = {version = "0.5.1"}
 /// leptos_chart = {version = "0.1.0", features = ["LineChart"]}
 /// ```
 ///
@@ -23,14 +23,14 @@ use theta_chart::coord;
 /// use leptos_chart::*;
 ///
 /// #[component]
-/// pub fn App(cx: Scope) -> impl IntoView {
+/// pub fn App() -> impl IntoView {
 ///     let chart = Cartesian::new(
 ///         Series::from(vec![1.0, 6.0, 9.]),
 ///         Series::from(vec![1.0, 3.0, 5.])
 ///     )
 ///     .set_view(820, 620, 3, 100, 100, 20);
 ///
-///     view!{ cx,
+///     view!{
 ///         <LineChart chart=chart />
 ///     }
 /// }
@@ -58,7 +58,7 @@ use theta_chart::coord;
 ///
 #[allow(non_snake_case)]
 #[component]
-pub fn LineChart(cx: Scope, chart: coord::Cartesian) -> impl IntoView {
+pub fn LineChart(chart: coord::Cartesian) -> impl IntoView {
     let cview = chart.get_view();
 
     // For Chart
@@ -97,7 +97,7 @@ pub fn LineChart(cx: Scope, chart: coord::Cartesian) -> impl IntoView {
     let ysticks = yseries.to_stick();
 
     if chart.get_error() == String::default() {
-        view! { cx,
+        view! {
 
             <SvgChart cview={cview}>
                 <g class="axes">
@@ -115,7 +115,7 @@ pub fn LineChart(cx: Scope, chart: coord::Cartesian) -> impl IntoView {
                         {
                             let vector = rec_chart.get_vector();
                             let path = format!("M {},{} l {},{} l {},{} l {},{} Z", 0, 0, vector.get_x(), 0, 0,vector.get_y(), -vector.get_x(), 0);
-                            view! {cx,
+                            view! {
                                 <circle id="originY" cx="0" cy="0" r="3" />
                                 <line x1="0" y1="0" x2=vector.get_x() y2=vector.get_y() style="stroke:#00ff0033;stroke-width:2" />
                                 <path id="regionY" d=path  fill="#00ff0033" />
@@ -130,12 +130,12 @@ pub fn LineChart(cx: Scope, chart: coord::Cartesian) -> impl IntoView {
                             let x: f64 = xseries.scale(data.value) * vector.get_x();
                             let y: f64 = yseries.scale(ysticks[index].value) *vector.get_y();
                             line.push_str(format!(" {:.0},{:.0} ", x, y).as_str());
-                            view! {cx,
+                            view! {
                                 <circle cx={x} cy={y}  r="2" stroke="black" stroke-width="1" fill="red" />
                             }
                         }).collect::<Vec<_>>();
 
-                        view! {cx,
+                        view! {
                             {point}
                             <path d={line} stroke="red" fill="none"/>
                         }
@@ -146,7 +146,7 @@ pub fn LineChart(cx: Scope, chart: coord::Cartesian) -> impl IntoView {
     } else {
         let err = chart.get_error();
         log::error!("{}", err);
-        view! {cx,
+        view! {
             <SvgChart cview={cview} >
                 <g></g>
             </SvgChart>

--- a/leptos_chart/src/linechart_group/components.rs
+++ b/leptos_chart/src/linechart_group/components.rs
@@ -14,7 +14,7 @@ use theta_chart::{color::Color, coord, series::Series};
 /// ```toml
 /// [dependencies]
 /// leptos = {version = "0.5.1"}
-/// leptos_chart = {version = "0.1.0", features = ["LineChartGroup"]}
+/// leptos_chart = {version = "0.2.0", features = ["LineChartGroup"]}
 /// ```
 ///
 /// ## Component

--- a/leptos_chart/src/linechart_group/components.rs
+++ b/leptos_chart/src/linechart_group/components.rs
@@ -2,7 +2,7 @@ use crate::{
     axes::{XAxis, YAxis},
     core::SvgChart,
 };
-use leptos::{component, view, IntoView, Scope};
+use leptos::{component, view, IntoView};
 use theta_chart::{color::Color, coord, series::Series};
 
 /// Component LineChart for leptos
@@ -13,7 +13,7 @@ use theta_chart::{color::Color, coord, series::Series};
 ///
 /// ```toml
 /// [dependencies]
-/// leptos = {version = "0.4.1"}
+/// leptos = {version = "0.5.1"}
 /// leptos_chart = {version = "0.1.0", features = ["LineChartGroup"]}
 /// ```
 ///
@@ -23,19 +23,19 @@ use theta_chart::{color::Color, coord, series::Series};
 /// use leptos_chart::*;
 ///
 /// #[component]
-/// pub fn App(cx: Scope) -> impl IntoView {
-///     let chart = CartesianGroup::new()    
-///         .set_view(840, 640, 3, 50, 50, 20)   
+/// pub fn App() -> impl IntoView {
+///     let chart = CartesianGroup::new()
+///         .set_view(840, 640, 3, 50, 50, 20)
 ///         .add_data(
 ///             Series::from((vec!["1982", "1986", "2010", "2020", ], "%Y", "year")),
-///             Series::from(vec![3., 2.0, 1., 4.]),        
+///             Series::from(vec![3., 2.0, 1., 4.]),
 ///         )
 ///         .add_data(
 ///             Series::from((vec!["1982", "1986", "2017", "2020"], "%Y", "year")),
-///             Series::from(vec![0., 1.0, 2., 3.]),        
+///             Series::from(vec![0., 1.0, 2., 3.]),
 ///         );
 ///
-///     view!{ cx,
+///     view!{
 ///         <LineChartGroup chart=chart />
 ///     }
 /// }
@@ -63,7 +63,7 @@ use theta_chart::{color::Color, coord, series::Series};
 ///
 #[allow(non_snake_case)]
 #[component]
-pub fn LineChartGroup(cx: Scope, chart: coord::CartesianGroup) -> impl IntoView {
+pub fn LineChartGroup(chart: coord::CartesianGroup) -> impl IntoView {
     let cview = chart.get_view();
 
     // For Chart
@@ -104,7 +104,7 @@ pub fn LineChartGroup(cx: Scope, chart: coord::CartesianGroup) -> impl IntoView 
         yseries.push(tup.1);
     }
 
-    view! { cx,
+    view! {
 
         <SvgChart cview={cview}>
 
@@ -123,7 +123,7 @@ pub fn LineChartGroup(cx: Scope, chart: coord::CartesianGroup) -> impl IntoView 
                     {
                         let vector = rec_chart.get_vector();
                         let path = format!("M {},{} l {},{} l {},{} l {},{} Z", 0, 0, vector.get_x(), 0, 0,vector.get_y(), -vector.get_x(), 0);
-                        view! {cx,
+                        view! {
                             <circle id="originY" cx="0" cy="0" r="3" />
                             <line x1="0" y1="0" x2=vector.get_x() y2=vector.get_y() style="stroke:#00ff0033;stroke-width:2" />
                             <path id="regionY" d=path  fill="#00ff0033" />
@@ -146,12 +146,12 @@ pub fn LineChartGroup(cx: Scope, chart: coord::CartesianGroup) -> impl IntoView 
                             let x: f64 = series_x_group.scale(d.value) * vector.get_x();
                             let y: f64 = series_y_group.scale(ysticks[i].value) *vector.get_y();
                             line.push_str(format!(" {:.0},{:.0} ", x, y).as_str());
-                            view! {cx,
+                            view! {
                                 <circle cx={x} cy={y}  r="3"  fill=color.to_string_hex() />
                             }
                         }).collect::<Vec<_>>();
 
-                        view! {cx,
+                        view! {
                             {point}
                             <path d={line} stroke={color.to_string_hex()} fill="none" stroke-width=2 />
                         }

--- a/leptos_chart/src/piechart/components.rs
+++ b/leptos_chart/src/piechart/components.rs
@@ -1,5 +1,5 @@
 use crate::core::{SvgPolar, REM};
-use leptos::{component, view, IntoView, Scope};
+use leptos::{component, view, IntoView};
 use theta_chart::{
     chart::{ScaleLabel, ScaleNumber},
     coord,
@@ -13,7 +13,7 @@ use theta_chart::{
 ///
 /// ```toml
 /// [dependencies]
-/// leptos = {version = "0.4.1"}
+/// leptos = {version = "0.5.1"}
 /// leptos_chart = {version = "0.1.0", features = ["PieChart"]}
 /// ```
 ///
@@ -23,14 +23,14 @@ use theta_chart::{
 /// use leptos_chart::*;
 ///
 /// #[component]
-/// pub fn App(cx: Scope) -> impl IntoView {
+/// pub fn App() -> impl IntoView {
 ///     let chart = Polar::new(
 ///         Series::from(vec![1.0, 2.0, 3.]),
 ///         Series::from(vec!["A", "B", "C"])
 ///     )
 ///     .set_view(740, 540, 2, 200, 20);
 ///
-///     view!{ cx,
+///     view!{
 ///         <PieChart chart=chart />
 ///     }
 /// }
@@ -56,7 +56,7 @@ use theta_chart::{
 ///
 #[allow(non_snake_case)]
 #[component]
-pub fn PieChart(cx: Scope, chart: coord::Polar) -> impl IntoView {
+pub fn PieChart(chart: coord::Polar) -> impl IntoView {
     let pview = chart.get_view();
 
     // For processing SNumber
@@ -83,7 +83,7 @@ pub fn PieChart(cx: Scope, chart: coord::Polar) -> impl IntoView {
         rec_label.get_origin().get_y(),
     );
 
-    view! { cx,
+    view! {
         <SvgPolar pview={pview}>
 
             <g class="labels" transform={translate_label}>
@@ -93,7 +93,7 @@ pub fn PieChart(cx: Scope, chart: coord::Polar) -> impl IntoView {
                     {
                         let vector = rec_label.get_vector();
                         let path = format!("M {},{} l {},{} l {},{} l {},{} Z", 0, 0, vector.get_x(), 0, 0,vector.get_y(), -vector.get_x(), 0);
-                        view! {cx,
+                        view! {
                             <circle id="origin" cx="0" cy="0" r="3" />
                             <line x1="0" y1="0" x2=vector.get_x() y2=vector.get_y() style="stroke:#005bbe33;stroke-width:1" />
                             <path id="regionX" d=path  fill="#005bbe33" />
@@ -104,7 +104,7 @@ pub fn PieChart(cx: Scope, chart: coord::Polar) -> impl IntoView {
                     slabel.labels().into_iter().enumerate().map(|(index, label)|  {
                         let color = &slabel.colors()[index];
                         let py = index as f64 * 1.5 * REM;
-                        view! {cx,
+                        view! {
                             <text x={1.5 * REM} y={py} dominant-baseline="text-before-edge">{format!("{}: {}",label, series[index])}</text>
                             <rect x={0} y={py + (1.5 - 1.0) * REM / 2.} width=REM height=REM fill={color.to_string_hex()}></rect>
                         }
@@ -117,7 +117,7 @@ pub fn PieChart(cx: Scope, chart: coord::Polar) -> impl IntoView {
                     #[cfg(all(feature = "debug"))]
                     {
                         let radius = circle_chart.get_radius();
-                        view! {cx,
+                        view! {
                             <circle id="origin" cx=0 cy=0 r=3 />
                             <circle id="circle" cx=0 cy=0 r=radius fill="#00ff0033"/>
                             <line x1="0" y1="0" x2=0 y2=-radius style="stroke:#00ff0033;stroke-width:2" />
@@ -129,7 +129,7 @@ pub fn PieChart(cx: Scope, chart: coord::Polar) -> impl IntoView {
                     vec_arc.into_iter().enumerate().map(|(index, data)|  {
                         let color = &slabel.colors()[index];
                         let radius = circle_chart.get_radius();
-                        view! {cx,
+                        view! {
                             <path  fill={color.to_string_hex()} stroke="#ffffff" stroke-width="1" d={data.gen_path(radius)} />
                         }
                     })

--- a/leptos_chart/src/piechart/components.rs
+++ b/leptos_chart/src/piechart/components.rs
@@ -14,7 +14,7 @@ use theta_chart::{
 /// ```toml
 /// [dependencies]
 /// leptos = {version = "0.5.1"}
-/// leptos_chart = {version = "0.1.0", features = ["PieChart"]}
+/// leptos_chart = {version = "0.2.0", features = ["PieChart"]}
 /// ```
 ///
 /// ## Component

--- a/leptos_chart/src/radarchart/components.rs
+++ b/leptos_chart/src/radarchart/components.rs
@@ -1,5 +1,5 @@
 use crate::core::{SvgPolar, REM};
-use leptos::{component, view, IntoView, Scope};
+use leptos::{component, view, IntoView};
 use theta_chart::{
     chart::{ScaleLabel, ScaleNumber},
     color::Color,
@@ -14,7 +14,7 @@ use theta_chart::{
 ///
 /// ```toml
 /// [dependencies]
-/// leptos = {version = "0.4.1"}
+/// leptos = {version = "0.5"}
 /// leptos_chart = {version = "0.1.0", features = ["RadarChart"]}
 /// ```
 ///
@@ -24,7 +24,7 @@ use theta_chart::{
 /// use leptos_chart::*;
 ///
 /// #[component]
-/// pub fn App(cx: Scope) -> impl IntoView {
+/// pub fn App() -> impl IntoView {
 ///
 ///     let chart = Polar::new(
 ///         Series::from(vec![85.0, 55.0, 45., 60., 40.]),
@@ -32,7 +32,7 @@ use theta_chart::{
 ///     )
 ///     .set_view(740, 540, 2, 0, 20);
 ///
-///     view! {cx,
+///     view! {
 ///         <div class="mx-auto p-8">
 ///             <RadarChart chart=chart />
 ///         </div>
@@ -61,7 +61,7 @@ use theta_chart::{
 ///
 #[allow(non_snake_case)]
 #[component]
-pub fn RadarChart(cx: Scope, chart: coord::Polar) -> impl IntoView {
+pub fn RadarChart(chart: coord::Polar) -> impl IntoView {
     let pview = chart.get_view();
 
     // For processing SNumber
@@ -88,14 +88,14 @@ pub fn RadarChart(cx: Scope, chart: coord::Polar) -> impl IntoView {
     //     rec_label.get_origin().get_y(),
     // );
 
-    view! { cx,
+    view! {
         <SvgPolar pview={pview}>
             <g class="inner-chart" transform={translate_chart} >
                 {
                     #[cfg(all(feature = "debug"))]
                     {
                         let radius = circle_chart.get_radius();
-                        view! {cx,
+                        view! {
                             <circle id="circle" cx=0 cy=0 r=radius fill="#00ff0033"/>
                         }
                     }
@@ -107,7 +107,7 @@ pub fn RadarChart(cx: Scope, chart: coord::Polar) -> impl IntoView {
                     grid_clone.into_iter().enumerate().map(|(index, vector)|  {
                         let point = vector.to_point();
                         let radius = radius *1.1;
-                        view! {cx,
+                        view! {
                             <line x1="0" y1="0" x2={point.get_x() * radius } y2={point.get_y() * radius} style="stroke:#00000011;stroke-width:1" />
                             <text x={point.get_x() * radius} y={point.get_y() * radius} dominant-baseline="middle" text-anchor="middle" opacity=0.5>{slabel.labels()[index].clone()}</text>
                         }
@@ -133,7 +133,7 @@ pub fn RadarChart(cx: Scope, chart: coord::Polar) -> impl IntoView {
                     grid050.push_str(" Z");
                     line.push_str(" Z");
                     let color = Color::default();
-                    view! {cx,
+                    view! {
                         <text x=0 y={radius * -0.5} dominant-baseline="middle" text-anchor="middle" opacity=0.3>50</text>
                         <text x=0  y={radius * -1.} dominant-baseline="middle" text-anchor="middle" opacity=0.3>100</text>
                         <text x=0  y=0 dominant-baseline="middle" text-anchor="middle" opacity=0.3>0</text>

--- a/leptos_chart/src/radarchart/components.rs
+++ b/leptos_chart/src/radarchart/components.rs
@@ -15,7 +15,7 @@ use theta_chart::{
 /// ```toml
 /// [dependencies]
 /// leptos = {version = "0.5"}
-/// leptos_chart = {version = "0.1.0", features = ["RadarChart"]}
+/// leptos_chart = {version = "0.2.0", features = ["RadarChart"]}
 /// ```
 ///
 /// ## Component

--- a/leptos_chart/src/scatterchart/components.rs
+++ b/leptos_chart/src/scatterchart/components.rs
@@ -2,7 +2,7 @@ use crate::{
     axes::{XAxis, YAxis},
     core::SvgChart,
 };
-use leptos::{component, view, IntoView, Scope};
+use leptos::{component, view, IntoView};
 use theta_chart::{color::Color, coord};
 
 /// Component ScatterChart for leptos
@@ -13,7 +13,7 @@ use theta_chart::{color::Color, coord};
 ///
 /// ```toml
 /// [dependencies]
-/// leptos = {version = "0.4.1"}
+/// leptos = {version = "0.5.1"}
 /// leptos_chart = {version = "0.1.0", features = ["ScatterChart"]}
 /// ```
 ///
@@ -23,14 +23,14 @@ use theta_chart::{color::Color, coord};
 /// use leptos_chart::*;
 ///
 /// #[component]
-/// pub fn App(cx: Scope) -> impl IntoView {
+/// pub fn App() -> impl IntoView {
 ///     let chart = Cartesian::new(
 ///         Series::from(vec![50,60,70,80,90,100,110,120,130,140,150]).set_range(40., 160.),
 ///         Series::from(vec![7,8,8,9,9,9,10,11,14,14,15]).set_range(6., 16.),
 ///     )
 ///     .set_view(820, 620, 3, 100, 100, 20);
 ///
-///     view!{ cx,
+///     view!{
 ///         <ScatterChart chart=chart />
 ///     }
 /// }
@@ -58,7 +58,7 @@ use theta_chart::{color::Color, coord};
 ///
 #[allow(non_snake_case)]
 #[component]
-pub fn ScatterChart(cx: Scope, chart: coord::Cartesian) -> impl IntoView {
+pub fn ScatterChart(chart: coord::Cartesian) -> impl IntoView {
     let cview = chart.get_view();
 
     // For Chart
@@ -95,7 +95,7 @@ pub fn ScatterChart(cx: Scope, chart: coord::Cartesian) -> impl IntoView {
     let xsticks = xseries.to_stick();
     let ysticks = yseries.to_stick();
 
-    view! { cx,
+    view! {
 
         <SvgChart cview={cview}>
             <g class="axes">
@@ -113,7 +113,7 @@ pub fn ScatterChart(cx: Scope, chart: coord::Cartesian) -> impl IntoView {
                     {
                         let vector = rec_chart.get_vector();
                         let path = format!("M {},{} l {},{} l {},{} l {},{} Z", 0, 0, vector.get_x(), 0, 0,vector.get_y(), -vector.get_x(), 0);
-                        view! {cx,
+                        view! {
                             <circle id="origin" cx="0" cy="0" r="3" />
                             <line x1="0" y1="0" x2=vector.get_x() y2=vector.get_y() style="stroke:#00ff0033;stroke-width:2" />
                             <path id="region" d=path  fill="#00ff0033" />
@@ -126,7 +126,7 @@ pub fn ScatterChart(cx: Scope, chart: coord::Cartesian) -> impl IntoView {
                     xsticks.into_iter().enumerate().map(|(index, data)|  {
                         let x: f64 = xseries.scale(data.value) * vector.get_x();
                         let y: f64 = yseries.scale(ysticks[index].value) *vector.get_y();
-                        view! {cx,
+                        view! {
                             <circle cx={x} cy={y}  r="4" fill=color.to_string_hex() />
                         }
                     }).collect::<Vec<_>>()

--- a/leptos_chart/src/scatterchart/components.rs
+++ b/leptos_chart/src/scatterchart/components.rs
@@ -14,7 +14,7 @@ use theta_chart::{color::Color, coord};
 /// ```toml
 /// [dependencies]
 /// leptos = {version = "0.5.1"}
-/// leptos_chart = {version = "0.1.0", features = ["ScatterChart"]}
+/// leptos_chart = {version = "0.2.0", features = ["ScatterChart"]}
 /// ```
 ///
 /// ## Component


### PR DESCRIPTION
I love this module....so I want to keep this upto date.

There are just a small number of changes, but each repeated many times. All in some way stripping out the Scope variable so ....

```
-pub fn App(cx: Scope) -> impl IntoView {
+pub fn App() -> impl IntoView {
```

```
-    view! {cx,
+    view! {
```

also this

```
-    leptos::mount_to_body(|cx| leptos::view! { cx,  <App/> })
+    leptos::mount_to_body(|| leptos::view! { <App/> })
```