### PR TITLE
I want to reduce the size of the svg element

### DIFF
--- a/leptos_chart/src/axes/xaxis.rs
+++ b/leptos_chart/src/axes/xaxis.rs
@@ -37,7 +37,7 @@ pub fn XAxis(region: Rec, axes: Axes) -> impl IntoView {
             }
         }
         // Draw x-axis
-        <g class="stick">
+        <g class="stick" dominant-baseline={baseline} text-anchor=text_anchor>
             <line x1="0" y1="0" x2=vector.get_x() y2="0" style="stroke:rgb(255,0,0)" />
             <line x1="0" y1="0" x2="0" y2={mark_origin_y} style="stroke:rgb(255,0,0)" />
                 {
@@ -48,8 +48,6 @@ pub fn XAxis(region: Rec, axes: Axes) -> impl IntoView {
                             <text
                                 y={mark_origin_y}
                                 x={dx}
-                                dominant-baseline={baseline}
-                                text-anchor=text_anchor
                                 style=style
                             >
                                 {stick.label}

--- a/leptos_chart/src/axes/yaxis.rs
+++ b/leptos_chart/src/axes/yaxis.rs
@@ -29,7 +29,7 @@ pub fn YAxis(region: Rec, axes: Axes) -> impl IntoView {
             }
         }
         // Draw y-axis
-        <g class="stick">
+        <g class="stick" dominant-baseline="middle" text-anchor=text_anchor >
             <line x1="0" y1="0" x2="0" y2=vector.get_y() style="stroke:rgb(0,0,255)" />
             <line x1="0" y1="0" x2=mark_origin_x y2="0" style="stroke:rgb(0,0,255)" />
 
@@ -41,8 +41,6 @@ pub fn YAxis(region: Rec, axes: Axes) -> impl IntoView {
                         <text
                             y=dy
                             x=mark_origin_x
-                            dominant-baseline="middle"
-                            text-anchor=text_anchor
                         >
                             {stick.label}
                         </text>


### PR DESCRIPTION
As an example ONLY the stroke can be moved up into the group element.

```
  <g fill="white" stroke="green" stroke-width="5">
    <circle cx="40" cy="40" r="25" />
    <circle cx="60" cy="60" r="25" />
  </g>
```

Looking at the x and y axes specifically as we loop over the sticks say 10 or 20 times...

axes.sticks.into_iter().map(|stick| {
  // ... svg repeated many times.
}

we can move the following text style up into the parent group.

dominant-baseline={baseline}
dominant-baseline={baseline}

I hope this helps.