### PR TITLE
Dark mode support

### DIFF
--- a/leptos_chart/src/axes/xaxis.rs
+++ b/leptos_chart/src/axes/xaxis.rs
@@ -50,6 +50,8 @@ pub fn XAxis(region: Rec, axes: Axes) -> impl IntoView {
                                 x={dx}
                                 dominant-baseline={baseline}
                                 text-anchor=text_anchor
+                                stroke="currentColor"
+                                fill="currentColor"
                                 style=style
                             >
                                 {stick.label}

--- a/leptos_chart/src/axes/yaxis.rs
+++ b/leptos_chart/src/axes/yaxis.rs
@@ -43,6 +43,8 @@ pub fn YAxis(region: Rec, axes: Axes) -> impl IntoView {
                             x=mark_origin_x
                             dominant-baseline="middle"
                             text-anchor=text_anchor
+                            stroke="currentColor"
+                            fill="currentColor"
                         >
                             {stick.label}
                         </text>


### PR DESCRIPTION
I really like this, module.. I have spent to weekend trying to get a side project to work .. 
Please excuse all the PR I have made.

When I switch my app between dark mode and normal mode. I see a problem, 
the axes labels 0, 10 20 30 ... are black in both normal mode and dark mode.

In short the labels vanish in dark mode, as the background-color is also dark.

This PR makes the labels visible in both dark and normal mode.

It is the first step in dark support.... I think there maybe other changes but this get me to where I want in just a few changes.


